### PR TITLE
Add JSON config for PDF extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # streamlit_test
 
 Extrait des infos en scannant avec de l'OCR tous les PDFs dans un dossier spécifié. Chaque PDF contient les données d'un adhérent d'un club de tennis. 
-Le but de ce programme est de générer un fichier csv pour rassembler ces infos, avec une ligne par adhérent
+Le but de ce programme est de générer un fichier csv pour rassembler ces infos, avec une ligne par adhérent.
+
+Les champs extraits peuvent être configurés dans le fichier `config.json`. Ce fichier est chargé au démarrage de l'application et peut être modifié depuis la barre latérale de l'interface Streamlit.

--- a/app.py
+++ b/app.py
@@ -2,7 +2,49 @@ import streamlit as st
 import pandas as pd
 import tempfile
 import os
-from extractor import extract_pdf
+import json
+import importlib
+import re
+import extractor
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config.json")
+
+def load_config():
+    with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+def save_config(cfg):
+    with open(CONFIG_PATH, "w", encoding="utf-8") as fh:
+        json.dump(cfg, fh, indent=2, ensure_ascii=False)
+
+cfg = load_config()
+
+with st.sidebar.expander("Configuration des champs"):
+    st.write("Champs actuels:")
+    for f in cfg:
+        st.write(f"- {f['name']} ({f['type']})")
+
+    with st.form("add_field"):
+        st.subheader("Ajouter un champ")
+        new_name = st.text_input("Nom du champ")
+        new_type = st.selectbox("Type", ["text", "number", "checkbox"])
+        submitted = st.form_submit_button("Ajouter")
+
+    if submitted and new_name:
+        entry = {
+            "name": new_name.upper(),
+            "type": new_type,
+            "acro_key": new_name.lower(),
+        }
+        if new_type == "checkbox":
+            cb = r"[xX✓✔☑☒✗✘❌■]"
+            entry["pattern"] = rf"(?:{cb}\s*{re.escape(new_name)})|(?:{re.escape(new_name)}[^\n]{{0,30}}{cb})"
+            entry["checked_value"] = "1"
+            entry["unchecked_value"] = "0"
+        cfg.append(entry)
+        save_config(cfg)
+        importlib.reload(extractor)
+        st.experimental_rerun()
 
 st.title("Tennis Club – Import PDF → CSV")
 
@@ -22,7 +64,7 @@ if uploaded_files:
                 tmp.flush()
                 tmp_path = tmp.name
             try:
-                data.append(extract_pdf(tmp_path))  # Passe le chemin du fichier
+                data.append(extractor.extract_pdf(tmp_path))  # Passe le chemin du fichier
             finally:
                 os.remove(tmp_path)  # Supprime le fichier temporaire après extraction
     df = pd.DataFrame(data)

--- a/config.json
+++ b/config.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "NOM",
+    "type": "text",
+    "pattern": "Nom\\s*:\\s*([^\\n]+?)(?:\\s+Pr[ée]nom|$)",
+    "acro_key": "nom"
+  },
+  {
+    "name": "PRÉNOM",
+    "type": "text",
+    "pattern": "Pr[ée]nom\\s*:\\s*([^\\n]+)",
+    "acro_key": "prénom"
+  },
+  {
+    "name": "NOUVEAU",
+    "type": "checkbox",
+    "pattern": "(?:[xX✓✔☑☒✗✘❌■]\\s*Nouvel\\s+adh[ée]rent)|(?:Nouvel\\s+adh[ée]rent[^\\n]{0,30}[xX✓✔☑☒✗✘❌■])",
+    "checked_value": "N",
+    "unchecked_value": "R",
+    "acro_key": "nouveau"
+  },
+  {
+    "name": "TEL",
+    "type": "number",
+    "pattern": "T[ée]l[ée]phone\\s*:\\s*([0-9 \\.\\-\\(\\)]{7,})",
+    "acro_key": "tel"
+  },
+  {
+    "name": "MAIL",
+    "type": "text",
+    "pattern": "[Ee]mail\\s*:\\s*([^\\s\\n]+)",
+    "acro_key": "mail"
+  }
+]


### PR DESCRIPTION
## Summary
- load extraction rules from `config.json`
- parse OCR text using configurable rules
- allow editing rules from sidebar in Streamlit app
- document configuration file in README

## Testing
- `python -m py_compile app.py extractor.py`
- `python extractor.py`

------
https://chatgpt.com/codex/tasks/task_e_6873e8688e548320a91c94f47c5024e6